### PR TITLE
Fix bsc#1216079

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,7 @@
 
 Metrics/LineLength:
   StyleGuide: https://github.com/SUSE/style-guides/blob/master/Ruby.md#metricslinelength
-  Max: 100
+  Max: 110
   # To make it possible to copy or click on URIs in the code, we allow lines
   # contaning a URI to be longer than Max.
   AllowURI: true
@@ -94,7 +94,7 @@ Style/NegatedIf:
 
 # Edited for yast-hana-update
 Metrics/MethodLength:
-  Max: 50
+  Max: 60
 
 # Edited for yast-hana-update
 Metrics/ClassLength:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM registry.opensuse.org/yast/sle-15/sp2/containers/yast-ruby
+COPY . /usr/src/app

--- a/package/yast2-hana-update.changes
+++ b/package/yast2-hana-update.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Thu Nov  9 10:07:21 UTC 2023 - Peter Varkoly <varkoly@suse.com>
+
+- Fix reformatting output of SAPHanaSR-showAttr
+- Azure - SAP HANA upgrade failure using YaST - Exception was:
+  Could not find virtual IP resource - SFSC 00708512 - ref:_00D1igLOd._5005qX8h2m:ref
+  (bsc#1216079)
+- 1.2.3
+
+-------------------------------------------------------------------
 Mon Nov 14 14:44:42 UTC 2022 - Peter Varkoly <varkoly@suse.com>
 
 - Wrong information in YaST2 module yast2-hana-update Step 4 of 7
@@ -9,7 +18,7 @@ Mon Nov 14 14:44:42 UTC 2022 - Peter Varkoly <varkoly@suse.com>
 Wed Dec 11 11:19:47 UTC 2019 - Peter Varkoly <varkoly@suse.com>
 
 - Version 1.2.1;
-- bsc#1158843 hana-*: Broken gettext support 
+- bsc#1158843 hana-*: Broken gettext support
 
 -------------------------------------------------------------------
 Tue Jun 05 09:44:55 UTC 2018 - imanyugin@suse.com

--- a/package/yast2-hana-update.spec
+++ b/package/yast2-hana-update.spec
@@ -17,7 +17,8 @@
 
 
 Name:           yast2-hana-update
-Version:        1.2.2
+=======
+Version:        1.2.3
 Release:        0
 %if 0%{?sle_version} >= 150000
 ExclusiveArch:  x86_64 ppc64le

--- a/package/yast2-hana-update.spec
+++ b/package/yast2-hana-update.spec
@@ -17,7 +17,6 @@
 
 
 Name:           yast2-hana-update
-=======
 Version:        1.2.3
 Release:        0
 %if 0%{?sle_version} >= 150000

--- a/src/lib/hana_update/cluster.rb
+++ b/src/lib/hana_update/cluster.rb
@@ -185,19 +185,19 @@ module HANAUpdater
       raise Exceptions::ClusterConfigurationError,
         "Could not find colocation rule for virtual IP" if vip_colocation.nil?
       vip_id = vip_colocation.attributes['rsc']
-      if is_azure?
+      if azure?
         vip_mon = REXML::XPath.first(
-	  mon_xml,
-	  '//crm_mon/resources/group[@id=$vip_id]/resource[@resource_agent="ocf::heartbeat:IPaddr2"]',
-	  nil,
-	  'vip_id' => vip_id
-	)
+          mon_xml,
+          '//crm_mon/resources/group[@id=$vip_id]/resource[@resource_agent="ocf::heartbeat:IPaddr2"]',
+          nil,
+          'vip_id' => vip_id
+        )
         vip_cib = REXML::XPath.first(
-	  cib_xml,
-	  '//cib/configuration/resources/group[@id=$vip_id]/primitive[@type="IPaddr2"]',
-	  nil,
-	  'vip_id' => vip_id
-	)
+          cib_xml,
+          '//cib/configuration/resources/group[@id=$vip_id]/primitive[@type="IPaddr2"]',
+          nil,
+          'vip_id' => vip_id
+        )
       else
         vip_mon = REXML::XPath.first(mon_xml,
           '//crm_mon/resources/resource[@id=$vip_id]',
@@ -223,8 +223,8 @@ module HANAUpdater
     end
 
     # check if the cluster is running on azure
-    def is_azure?
-      result = %x(dmidecode -t system | grep Manufacturer)
+    def azure?
+      result = `dmidecode -t system | grep Manufacturer`
       if result.strip.to_s == "Manufacturer: Microsoft Corporation"
         url_metadata = URI.parse("http://168.63.129.16/?comp=versions")
         meta_service = Net::HTTP.new(url_metadata.host)
@@ -247,7 +247,6 @@ module HANAUpdater
         return false
       end
     end
-
   end
 
   # Cluster abstraction class

--- a/src/lib/hana_update/executor.rb
+++ b/src/lib/hana_update/executor.rb
@@ -87,7 +87,7 @@ module HANAUpdater
 
     # Bring the cluster to a state where the admin can update the (former) primary instance
     # @param config [HANAUpdater::Config]
-    def execute_remote_update_plan(config) # rubocop:disable Metrics/MethodLength
+    def execute_remote_update_plan(config)
       log.info "--- called #{self.class}.#{__callee__} ---"
       sap_sys = config.system
       remote_node = sap_sys.master.remote.running_on.name

--- a/src/lib/hana_update/system.rb
+++ b/src/lib/hana_update/system.rb
@@ -103,19 +103,24 @@ module HANAUpdater
 
     # Execute SAPHanaSR-showAttr and parse its output
     def saphanasr_attributes(sid)
-      cmd = 'SAPHanaSR-showAttr', "--sid=#{sid}"
+      cmd = 'SAPHanaSR-showAttr', "--sid=#{sid}", "--format=script"
       out, status = exec_get_output(*cmd)
       return nil if status.exitstatus != 0
-      lines = []
-      start = false
-      out.split("\n").each_with_index do |line, _ix|
-        next unless start || line.start_with?('Hosts')
-        start = true
-        unless /\A-+\Z/ =~ line # rubocop:disable Style/Next
-          spl = line.split
-          spl.insert(4, '') if spl.length < 13
-          lines << spl
-        end
+      head    = []
+      values  = {}
+      lines   = []
+      out.each_line do |line|
+        next unless line.start_with?('Hosts')
+        tmp = /Hosts\/(.*)\/(.*)="(.*)"/.match(line)
+        head << tmp[2] unless head.include?(tmp[2])
+        values[tmp[1]] = {} if values[tmp[1]].nil?
+        values[tmp[1]][tmp[2]] = tmp[3]
+      end
+      lines << head
+      values.each_key do |host|
+        line = []
+        head.each { |key| line << values[host][key] }
+        lines << line
       end
       lines
     end


### PR DESCRIPTION
## Problem

*The yast-hana-update module can not handle HANA HA configuration on azure because the IP-address primitve on azure is part of a resource group.*

- *https://bugzilla.suse.com/show_bug.cgi?id=1216079*

## Solution

Create new function to test if the cluster is in an azure cloude. In this case search for virtual IP in the load balancer resource group
