### PR TITLE
Update comes from SUSE:SLE-15-SP2:Update

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,8 @@
 
 require 'yast/rake'
 
-Yast::Tasks.submit_to :sle15sp3
+# Update comes from codestream SUSE:SLE-15-SP2:Update
+# Yast::Tasks.submit_to :sle15sp3
 require 'packaging'
 
 Yast::Tasks.configuration do |conf|


### PR DESCRIPTION
## Updates for this package comes from codestream SUSE:SLE-15-SP2:Update for SP3 and SP4

The automatic checkins for the last changes were declined because the updates for this package comes from codestream SUSE:SLE-15-SP2:Update for SP3 and SP4. That's why I have to continue to maintain the branch SLE-15-SP2 and to stop automatic submit requests from SLE-15-SP3 and SLE-15-SP4.